### PR TITLE
devDependencies in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,9 @@
   "name": "leaflet-active-area",
   "version": "0.1.0",
   "dependencies": {
-    "leaflet-dist": "http://leaflet-cdn.s3.amazonaws.com/build/leaflet-0.7.2.zip",
+    "leaflet-dist": "http://leaflet-cdn.s3.amazonaws.com/build/leaflet-0.7.2.zip"
+  },
+  "devDependencies": {
     "sinon": "~1.9.0",
     "expect": "~0.3.1"
   }


### PR DESCRIPTION
Move `sinon` and `expect` to `devDependencies` to reduce clutter when installed via bower.
