### PR TITLE
Use default zoom in setView() if zoom is not specified

### DIFF
--- a/src/leaflet.activearea.js
+++ b/src/leaflet.activearea.js
@@ -73,6 +73,7 @@ L.Map.include({
 
     setView: function (center, zoom, options) {
         center = L.latLng(center);
+        zoom = zoom || this.getZoom();
 
         if (this.getViewport()) {
             var point = this.project(center, this._limitZoom(zoom));


### PR DESCRIPTION
Leaflet `setView()` function allows to set only latLng coordinates without zoom. 