### PR TITLE
fix setView with zoom 0 and use the same code as the overwritten setView

### DIFF
--- a/src/leaflet.activearea.js
+++ b/src/leaflet.activearea.js
@@ -73,7 +73,7 @@ L.Map.include({
 
     setView: function (center, zoom, options) {
         center = L.latLng(center);
-        zoom = zoom || this.getZoom();
+        zoom = zoom === undefined ? this._zoom : this._limitZoom(zoom);
 
         if (this.getViewport()) {
             var point = this.project(center, this._limitZoom(zoom));


### PR DESCRIPTION
fix setView with zoom 0 and use the same code as the overwritten setView

should probably also be applied to master branch, at least in the form
zoom === undefined ? this.getZoom() : zoom;