### PR TITLE
fix main file to make it require-able

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "leaflet-active-area",
   "version": "0.1.0",
+  "main": "src/leaflet.activearea.js",
   "devDependencies": {
     "mocha": "~1.17.1",
     "happen": "~0.1.3",


### PR DESCRIPTION
Make it work so people can use npm and browserify.

```console
npm install leaflet leaflet-active-area
```

```javascript
import * as L from 'leaflet';
import * from 'leaflet-active-area';

const map = new L.Map('map', {}).setActiveArea('leaflet-active-area'); 
```