### PR TITLE
Fixes issue #21 where the dots of a Torque layer would be wrongly positioned

### DIFF
--- a/src/leaflet.activearea.js
+++ b/src/leaflet.activearea.js
@@ -52,9 +52,31 @@ L.Map.include({
         return L.latLngBounds(this.containerPointToLatLng(bounds.min), this.containerPointToLatLng(bounds.max));
     },
 
+    _hasTorqueLayer: function() {
+        if(!L.TorqueLayer) return false;
+
+        var keys = Object.keys(this._layers);
+
+        for(var i = 0, j = keys.length; i < j; i++) {
+            if(this._layers[keys[i]] instanceof L.TorqueLayer) {
+                return true;
+            }
+        }
+
+        return false;
+    },
+
     getOffset: function() {
         var mCenter = this.getSize().divideBy(2),
             vCenter = this.getViewportBounds().getCenter();
+
+        /* If one of the map layer is a Torque, we wan't to return the center
+         * of the map and not the one of the viewport because it messes up the
+         * position of the dots on the map (offset them by the difference
+         * between mCenter and vCenter) */
+        if(this._hasTorqueLayer()) {
+            return L.point([0, 0]);
+        }
 
         return mCenter.subtract(vCenter);
     },


### PR DESCRIPTION
This PR is aimed to solve issue #21 where all the dots of a Torque layer have an offset of the difference between the real map center and the center of the restricted/active area. This leads the dots to have a wrong position.

Here is an example of the issue: 

![Screenshot of the issue](https://cloud.githubusercontent.com/assets/6073968/17019984/7d0cdae8-4f3f-11e6-8011-60958022821a.png)

As you can see, all the dots are above their real positions (take a look at the UK and Spain). The red rectangle is the div used for the active area.
I created a JS bin for you to see it in action: http://jsbin.com/sukeyonuzo/edit?html,output

With the fix I provide, the same code makes the map return to normality:

![After the fix, the map looks normal](https://cloud.githubusercontent.com/assets/6073968/17020045/daa3f57e-4f3f-11e6-86d5-ab7645f91bcb.png)

This is the JS bin for this example: http://jsbin.com/fuyomapita/edit?html,output
The difference between the two JS bins is that I removed your version of the library and directly embedded my version with the fix.

Please note that I don't think my fix is the best solution to handle Torque. Indeed, if the map contains a tile layer and a Torque one, both of them will get the true map center instead of the center of the active area, so it can have side effects.

If you need more help with that I'd be happy to help.

Clément
