### PR TITLE
Add missing recommended Bower keys

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,14 @@
 {
   "name": "leaflet-active-area",
   "version": "0.1.0",
+  "main": "src/leaflet.activearea.js",
+  "ignore": [
+    ".*",
+    "*.md",
+    "examples",
+    "spec",
+    "package.json"
+  ],
   "dependencies": {
     "leaflet": "0.7.7"
   },


### PR DESCRIPTION
Add missing recommended keys to `bower.json`. Otherwise when installing, it complains:

```
bower leaflet-active-area#*     invalid-meta leaflet-active-area is missing "main" entry in bower.json
bower leaflet-active-area#*     invalid-meta leaflet-active-area is missing "ignore" entry in bower.json
```

See:
- https://github.com/bower/spec/blob/master/json.md#main
- https://github.com/bower/spec/blob/master/json.md#ignore