### PR TITLE
Fix _update to use zoom value from Leaflet

### DIFF
--- a/src/leaflet.activearea.js
+++ b/src/leaflet.activearea.js
@@ -305,7 +305,7 @@ L.GridLayer.include({
     _update: function (center) {
         var map = this._map;
         if (!map) { return; }
-        var zoom = map.getZoom();
+        var zoom = this._clampZoom(map.getZoom());
 
         if (center === undefined) { center = map.getCenter(this); }
         if (this._tileZoom === undefined) { return; }    // if out of minzoom/maxzoom


### PR DESCRIPTION
Fix the _update method to use the same zoom value that Leaflet does. Should resolve issue https://github.com/Mappy/Leaflet-active-area/issues/32